### PR TITLE
Adding bookworm and trixie to matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,6 +101,20 @@ jobs:
               "cacher": "",
             }
           - {
+              "target": "trixie-backports",
+              "mirror": "http://deb.debian.net",
+              "user": "root",
+              "command": "sh",
+              "cacher": "apt-cacher-ng",
+            }
+          - {
+              "target": "bookworm-backports",
+              "mirror": "http://deb.debian.net",
+              "user": "root",
+              "command": "sh",
+              "cacher": "apt-cacher-ng",
+            }
+          - {
               "target": "bullseye-backports",
               "mirror": "http://deb.debian.net",
               "user": "root",


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Include trixie-backports and bookworm-backports as new targets in the CI workflow matrix